### PR TITLE
Add stream position to the event metadata

### DIFF
--- a/Scheduling.Test/Test/HandlerTest.cs
+++ b/Scheduling.Test/Test/HandlerTest.cs
@@ -23,31 +23,36 @@ public abstract class HandlerTest
         var correlationId = new CorrelationId(Guid.NewGuid());
         var causationId = new CausationId(Guid.NewGuid());
 
+        ulong i = 0;
         foreach (var @event in events)
         {
             var metadata = new EventMetadata(
-                @event.GetType().FullName!,
                 correlationId,
-                causationId
+                causationId,
+                i
             );
                 
             await _eventHandler.Handle(@event.GetType(), @event, metadata);
 
             if (EnableAtLeastOnceMonkey)
                 await _eventHandler.Handle(@event.GetType(), @event, metadata);
+
+            i++;
         }
 
         if (EnableAtLeastOnceGorilla)
         {
+            i = 0;
             foreach (var @event in events.Take(events.Length - 1))
             {
                 var metadata = new EventMetadata(
-                    @event.GetType().FullName!,
                     correlationId,
-                    causationId
+                    causationId,
+                    i
                 );
                     
                 await _eventHandler.Handle(@event.GetType(), @event, metadata);
+                i++;
             }
         }
     }

--- a/Scheduling/EventSourcing/EventMetadata.cs
+++ b/Scheduling/EventSourcing/EventMetadata.cs
@@ -1,7 +1,14 @@
+using Newtonsoft.Json;
+
 namespace Scheduling.EventSourcing;
 
 public record EventMetadata(
-    string ClrType,
     CorrelationId CorrelationId,
-    CausationId CausationId
-);
+    CausationId CausationId,
+    [property: JsonIgnore] 
+    ulong? Position = null
+)
+{
+    public static EventMetadata From(CommandMetadata commandMetadata) =>
+        new(commandMetadata.CorrelationId, commandMetadata.CausationId);
+}

--- a/Scheduling/Infrastructure/EventStore/EsEventSerde.cs
+++ b/Scheduling/Infrastructure/EventStore/EsEventSerde.cs
@@ -16,7 +16,7 @@ public static class EsEventSerde
         return dataToType(data);
     }
 
-    public static EventData Serialize(this object @event, Uuid uuid, CommandMetadata metadata)
+    public static EventData Serialize(this object @event, Uuid uuid, EventMetadata metadata)
     {
         var typeToData = TypeMapper.GetTypeToData(@event.GetType());
         var (name, jObject) = typeToData(@event);
@@ -28,7 +28,6 @@ public static class EsEventSerde
             data,
             Serialize(
                 new EventMetadata(
-                    @event.GetType().FullName!,
                     metadata.CorrelationId,
                     metadata.CausationId
                 )
@@ -48,7 +47,10 @@ public static class EsEventSerde
     public static EventMetadata DeserializeMetadata(this ResolvedEvent resolvedEvent)
     {
         var jsonData = Encoding.UTF8.GetString(resolvedEvent.Event.Metadata.ToArray());
-        return JsonConvert.DeserializeObject<EventMetadata>(jsonData)!;
+        return JsonConvert.DeserializeObject<EventMetadata>(jsonData)! with
+        {
+            Position = resolvedEvent.Event.Position.CommitPosition
+        };
     }
 
     public static EventData SerializeSnapshot(this object snapshot, SnapshotMetadata metadata)

--- a/Scheduling/Infrastructure/EventStore/EsEventStore.cs
+++ b/Scheduling/Infrastructure/EventStore/EsEventStore.cs
@@ -36,7 +36,7 @@ public class EsEventStore : IEventStore
 
         var preparedEvents = events.Select(e => e.Serialize(
             Uuid.NewUuid(),
-            metadata
+            EventMetadata.From(metadata)
         )).ToList();
 
         if (version == -1)
@@ -56,7 +56,7 @@ public class EsEventStore : IEventStore
 
         var preparedEvents = events.Select(e => e.Serialize(
             Uuid.NewUuid(),
-            metadata
+            EventMetadata.From(metadata)
         )).ToList();
 
         return _client.AppendToStreamAsync(_tenantPrefix + streamName, StreamState.Any, preparedEvents);

--- a/Scheduling/Infrastructure/Headers/CommandMetadataOperationFilter.cs
+++ b/Scheduling/Infrastructure/Headers/CommandMetadataOperationFilter.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Scheduling.Infrastructure.Headers;
+
+public class CommandMetadataOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        operation.Parameters ??= new List<OpenApiParameter>();
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "X-CorrelationId",
+            In= ParameterLocation.Header,
+            Description = "Correlation Id",
+            Required = true
+        });
+        
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "X-CausationId",
+            In= ParameterLocation.Header,
+            Description = "Causation Id",
+            Required = true
+        });
+    }
+}

--- a/Scheduling/Program.cs
+++ b/Scheduling/Program.cs
@@ -4,6 +4,7 @@ using EventStore.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using MongoDB.Driver;
 using Scheduling;
@@ -12,6 +13,7 @@ using Scheduling.Domain.DoctorDay.Events;
 using Scheduling.Domain.ReadModel;
 using Scheduling.EventSourcing;
 using Scheduling.Infrastructure.EventStore;
+using Scheduling.Infrastructure.Headers;
 using Scheduling.Infrastructure.InMemory;
 using Scheduling.Infrastructure.MongoDb;
 using Scheduling.Infrastructure.Projections;
@@ -33,6 +35,12 @@ services.AddSingleton<IEventStore>(eventStore)
     .AddSwaggerGen(c =>
     {
         c.SwaggerDoc("v1", new OpenApiInfo { Title = "Patients API", Description = "API for booking doctor appointments", Version = "v1" });
+        c.OperationFilter<CommandMetadataOperationFilter>();
+        c.MapType<TimeSpan>(() => new OpenApiSchema
+        {
+            Type = "string",
+            Example = new OpenApiString("00:00:00")
+        });
     });
 
 EventMappings.MapEventTypes();

--- a/Scheduling/Properties/launchSettings.json
+++ b/Scheduling/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "swagger/index.html",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
- Corrects invalid use of CommandMetadata in event handlers and uses EventMetadata instead
- Adds position to the EventMetadata
- Added Causation and Correlation Ids, so Swagger is actually usable