### PR TITLE
Corrected target framework in `Scheduling.Test.csproj`

### DIFF
--- a/Scheduling.Test/Scheduling.Test.csproj
+++ b/Scheduling.Test/Scheduling.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp6.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>


### PR DESCRIPTION
Hey there 👋 

I noticed that `<TargetFramework>` in `Scheduling.Test.csproj` was set to `netcoreapp6.0`, as opposed to `net6.0` which is usually used, so I thought I'd correct it. 

I've tested the change locally and all tests still pass 👍 